### PR TITLE
retry buffer added

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -1,0 +1,30 @@
+package influxdb
+
+import (
+	"github.com/influxdata/influxdb/client/v2"
+)
+
+func NewBuffer(size int) *Buffer {
+	return &Buffer{
+		data: []client.BatchPoints{},
+		size: size,
+	}
+}
+
+type Buffer struct {
+	data []client.BatchPoints
+	size int
+}
+
+func (b *Buffer) Add(ps ...client.BatchPoints) {
+	b.data = append(b.data, ps...)
+	if len(b.data) > b.size {
+		b.data = b.data[len(b.data)-b.size:]
+	}
+}
+
+func (b *Buffer) Elements() []client.BatchPoints {
+	var res []client.BatchPoints
+	res, b.data = b.data, []client.BatchPoints{}
+	return res
+}

--- a/config.go
+++ b/config.go
@@ -7,12 +7,15 @@ import (
 	"github.com/devopsfaith/krakend/config"
 )
 
+const defaultBufferSize = 0
+
 type influxConfig struct {
-	address  string
-	username string
-	password string
-	ttl      time.Duration
-	database string
+	address    string
+	username   string
+	password   string
+	ttl        time.Duration
+	database   string
+	bufferSize int
 }
 
 func configGetter(extraConfig config.ExtraConfig) interface{} {
@@ -38,6 +41,12 @@ func configGetter(extraConfig config.ExtraConfig) interface{} {
 
 	if value, ok := castedConfig["password"]; ok {
 		cfg.password = value.(string)
+	}
+
+	if value, ok := castedConfig["buffer_size"]; ok {
+		if s, ok := value.(int); ok {
+			cfg.bufferSize = s
+		}
 	}
 
 	if value, ok := castedConfig["ttl"]; ok {


### PR DESCRIPTION
this PR adds a simple buffer for storing failed batch points until they can be sent successfully or the `buffer_size` is reached.

When the limit is exceeded, the buffer just dumps the oldest batches